### PR TITLE
Test for Observable.empty()

### DIFF
--- a/src/test/java/io/jmnarloch/spring/boot/rxjava/async/ObservableDeferredResultTest.java
+++ b/src/test/java/io/jmnarloch/spring/boot/rxjava/async/ObservableDeferredResultTest.java
@@ -69,6 +69,11 @@ public class ObservableDeferredResultTest {
     @RestController
     protected static class Application {
 
+        @RequestMapping(method = RequestMethod.GET, value = "/empty")
+        public ObservableDeferredResult<String> empty() {
+            return new ObservableDeferredResult<String>(Observable.<String>empty());
+        }
+
         @RequestMapping(method = RequestMethod.GET, value = "/single")
         public ObservableDeferredResult<String> single() {
             return new ObservableDeferredResult<String>(Observable.just("single value"));
@@ -103,6 +108,18 @@ public class ObservableDeferredResultTest {
                 }
             }));
         }
+    }
+
+    @Test
+    public void shouldRetrieveEmptyResponse() {
+
+        // when
+        ResponseEntity<List> response = restTemplate.getForEntity(path("/empty"), List.class);
+
+        // then
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(Collections.emptyList(), response.getBody());
     }
 
     @Test

--- a/src/test/java/io/jmnarloch/spring/boot/rxjava/mvc/ObservableReturnValueHandlerTest.java
+++ b/src/test/java/io/jmnarloch/spring/boot/rxjava/mvc/ObservableReturnValueHandlerTest.java
@@ -64,6 +64,11 @@ public class ObservableReturnValueHandlerTest {
     @RestController
     protected static class Application {
 
+        @RequestMapping(method = RequestMethod.GET, value = "/empty")
+        public Observable<Void> empty() {
+            return Observable.empty();
+        }
+
         @RequestMapping(method = RequestMethod.GET, value = "/single")
         public Observable<String> single() {
             return Observable.just("single value");
@@ -88,6 +93,18 @@ public class ObservableReturnValueHandlerTest {
                 }
             });
         }
+    }
+
+    @Test
+    public void shouldRetrieveEmptyResponse() {
+
+        // when
+        ResponseEntity<List> response = restTemplate.getForEntity(path("/empty"), List.class);
+
+        // then
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(Collections.emptyList(), response.getBody());
     }
 
     @Test


### PR DESCRIPTION
Additional test for Observable.empty() (similar to experimental Completable from newer rx-java version), to show that empty observables are also supported (it's not obvious because empty observable never calls onNext). 
