### PR TITLE
Fixing collision with netflix-core library.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.github.kt3k.coveralls'
 
 sourceCompatibility = 1.7
 
-group = "io.jmnarloch"
+group = "com.github.ikamman"
 archivesBaseName="rxjava-spring-boot-starter"
 
 ext {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 #Sun, 27 Nov 2016 18:29:36 -0800
-version=2.0.1-SNAPSHOT
+version=2.0.1

--- a/src/main/java/io/jmnarloch/spring/boot/rxjava/config/RxJavaMvcAutoConfiguration.java
+++ b/src/main/java/io/jmnarloch/spring/boot/rxjava/config/RxJavaMvcAutoConfiguration.java
@@ -46,7 +46,7 @@ public class RxJavaMvcAutoConfiguration {
     @RxJava
     @ConditionalOnMissingBean
     @ConditionalOnClass(Observable.class)
-    public ObservableReturnValueHandler observableReturnValueHandler() {
+    public ObservableReturnValueHandler rx2observableReturnValueHandler() {
         return new ObservableReturnValueHandler();
     }
 
@@ -54,7 +54,7 @@ public class RxJavaMvcAutoConfiguration {
     @RxJava
     @ConditionalOnMissingBean
     @ConditionalOnClass(Single.class)
-    public SingleReturnValueHandler singleReturnValueHandler() {
+    public SingleReturnValueHandler rx2singleReturnValueHandler() {
         return new SingleReturnValueHandler();
     }
 


### PR DESCRIPTION
The netflix-core uses the same name of the factory method for Single return type, even then when types got different canonical names. For factory methods spring use the method name strategy. The @RxJava will take place only for the same bean type. 