### PR TITLE
fix timeout handling

### DIFF
--- a/src/main/java/io/jmnarloch/spring/boot/rxjava/async/ObservableDeferredResult.java
+++ b/src/main/java/io/jmnarloch/spring/boot/rxjava/async/ObservableDeferredResult.java
@@ -29,20 +29,14 @@ import java.util.List;
  */
 public class ObservableDeferredResult<T> extends DeferredResult<List<T>> {
 
-    private static final Object EMPTY_RESULT = new Object();
-
     private final DeferredResultObserver<List<T>> observer;
 
     public ObservableDeferredResult(Observable<T> observable) {
-        this(null, EMPTY_RESULT, observable);
+        this(null, observable);
     }
 
-    public ObservableDeferredResult(long timeout, Observable<T> observable) {
-        this(timeout, EMPTY_RESULT, observable);
-    }
-
-    public ObservableDeferredResult(Long timeout, Object timeoutResult, Observable<T> observable) {
-        super(timeout, timeoutResult);
+    public ObservableDeferredResult(Long timeout, Observable<T> observable) {
+        super(timeout);
         Assert.notNull(observable, "observable can not be null");
 
         observer = new DeferredResultObserver<List<T>>(observable.toList().toObservable(), this);

--- a/src/main/java/io/jmnarloch/spring/boot/rxjava/async/SingleDeferredResult.java
+++ b/src/main/java/io/jmnarloch/spring/boot/rxjava/async/SingleDeferredResult.java
@@ -27,20 +27,14 @@ import io.reactivex.Single;
  */
 public class SingleDeferredResult<T> extends DeferredResult<T> {
 
-    private static final Object EMPTY_RESULT = new Object();
-
     private final DeferredResultObserver<T> observer;
 
     public SingleDeferredResult(Single<T> single) {
-        this(null, EMPTY_RESULT, single);
+        this(null, single);
     }
 
-    public SingleDeferredResult(long timeout, Single<T> single) {
-        this(timeout, EMPTY_RESULT, single);
-    }
-
-    public SingleDeferredResult(Long timeout, Object timeoutResult, Single<T> single) {
-        super(timeout, timeoutResult);
+    public SingleDeferredResult(Long timeout, Single<T> single) {
+        super(timeout);
         Assert.notNull(single, "single can not be null");
 
         observer = new DeferredResultObserver<T>(single.toObservable(), this);


### PR DESCRIPTION
When async request timeout occurred, 500 status returned.
I expected to return 503 status.

When timeout occur, async processing results ObservableDeferredResult.EMPTY_RESULT.
If EMPTY_RESULT return as return value, IllegalArgumentException had "No converter found for java.lang.Object" as message occurs.

